### PR TITLE
Include targetdocker in .dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 target
+targetdocker
 Cargo.lock


### PR DESCRIPTION
This reduces docker build time.