### PR TITLE
Use .is_present and individual .arg_from_usages lines in Clap.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ fn execute(args: &ArgMatches) -> Result<i32, error::FatalError> {
             config::get_release_config(&cargo_file, config::DOC_COMMIT_MESSAGE)
                 .and_then(|f| f.as_str())
         })
-        .and_then(|f| f.as_str())
         .unwrap_or("(cargo-gh-pages) Generate docs.");
 
     // Check if working directory is clean.


### PR DESCRIPTION
* Makes `--doc-commit-message` a commandline option also.